### PR TITLE
fix: update multipublish command to use pnpm in release workflow

### DIFF
--- a/.changeset/long-berries-shout.md
+++ b/.changeset/long-berries-shout.md
@@ -1,0 +1,5 @@
+---
+"@stephansama/multipublish": patch
+---
+
+arbitrary bump to trigger publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,4 +77,4 @@ jobs:
       - name: publish to other registries
         if: steps.changesets.outputs.published == 'true'
         run: |
-          echo "${{ steps.changesets.outputs.publishedPackages }}" | multipublish
+          echo "${{ steps.changesets.outputs.publishedPackages }}" | pnpm multipublish


### PR DESCRIPTION
**Checklist**

- Latest changes from `main` have been merged
- Conflicts have been resolved
- The branch is pointing to `main`
- Eslint hasn't reported any issues.
- All unit tests pass
