### PR TITLE
feat(config): add npmgraph badge to autoreadmerc.json

### DIFF
--- a/.config/autoreadmerc.json
+++ b/.config/autoreadmerc.json
@@ -36,7 +36,7 @@
       },
       {
         "url": "https://npmgraph.js.org/?q={{escaped_name}}",
-        "image": "https://img.shields.io/badge/npmgraph-211F1F?style=flat&logo=graphql&logoColor=white&labelColor=211F1F",
+        "image": "https://img.shields.io/badge/npmgraph-211F1F?style=flat&logo=npm&logoColor=white&labelColor=211F1F",
         "label": "npmgraph"
       }
     ]

--- a/.config/autoreadmerc.json
+++ b/.config/autoreadmerc.json
@@ -33,6 +33,11 @@
         "url": "https://www.npmx.dev/package/{{name}}",
         "image": "https://img.shields.io/npm/dw/{{name}}?labelColor=211F1F",
         "label": "npm downloads"
+      },
+      {
+        "url": "https://npmgraph.js.org/?q={{escaped_name}}",
+        "image": "https://img.shields.io/badge/npmgraph-211F1F?style=flat&logo=graphql&logoColor=white&labelColor=211F1F",
+        "label": "npmgraph"
       }
     ]
   },


### PR DESCRIPTION
Closes STE-164

Adds a per-package "npmgraph" badge to the BADGE row generated by `auto-readme`. The `badgeOptions.templates` array in `.config/autoreadmerc.json` already supports arbitrary entries — no source change to `core/auto-readme`. Uses `{{escaped_name}}` (i.e. `encodeURIComponent(name)`) so scoped packages like `@stephansama/foo` URL-encode correctly when linking to npmgraph.js.org.

## Acceptance criteria
- [x] One new entry added to `badgeOptions.templates` in `.config/autoreadmerc.json`.
- [x] Zero edits to `core/auto-readme/` source — the package handles the new entry out of the box.
- [ ] Re-running `auto-readme` against any package emits a new "npmgraph" badge in the BADGE zone (verify on next release).