### PR TITLE
feat(ai-commit-msg): support XDG_CONFIG_HOME config files

### DIFF
--- a/core/ai-commit-msg/package.json
+++ b/core/ai-commit-msg/package.json
@@ -53,6 +53,8 @@
     "neverthrow": "catalog:",
     "obug": "catalog:cli",
     "ollama-ai-provider-v2": "catalog:ai",
+    "smol-toml": "catalog:",
+    "xdg-app-paths": "^8.3.0",
     "yargs": "catalog:cli",
     "zod": "catalog:schema"
   },

--- a/core/ai-commit-msg/src/config.ts
+++ b/core/ai-commit-msg/src/config.ts
@@ -1,9 +1,25 @@
-import { cosmiconfig, getDefaultSearchPlaces, type Options } from "cosmiconfig";
+import {
+	cosmiconfig,
+	defaultLoaders,
+	getDefaultSearchPlaces,
+	type Loader,
+	type Options,
+} from "cosmiconfig";
+import path from "node:path";
+import { parse as parseToml } from "smol-toml";
+import xdgAppPaths from "xdg-app-paths";
 
 import { type Config, configSchema } from "./schema";
 import { moduleName } from "./utilities";
 
 const searchPlaces = getSearchPlaces();
+
+const tomlLoader: Loader = (_filepath, content) => parseToml(content);
+
+const loaders = {
+	...defaultLoaders,
+	".toml": tomlLoader,
+};
 
 const defaultConfig = {
 	model: "llama2",
@@ -12,7 +28,7 @@ const defaultConfig = {
 } satisfies Config;
 
 export async function loadConfig() {
-	const options: Partial<Options> = { searchPlaces };
+	const options: Partial<Options> = { loaders, searchPlaces };
 
 	const explorer = cosmiconfig(moduleName, options);
 
@@ -22,11 +38,21 @@ export async function loadConfig() {
 }
 
 function getSearchPlaces() {
+	// XDG paths come AFTER project-local paths, so project config wins.
+	const xdgConfigDirectory = path.join(
+		xdgAppPaths(moduleName).config(),
+		"config",
+	);
+
 	return [
 		...getDefaultSearchPlaces(moduleName),
 		`.config/.${moduleName}rc.json`,
 		`.config/.${moduleName}rc.yaml`,
 		`.config/.${moduleName}rc.yml`,
 		`.config/.${moduleName}rc`,
+		`${xdgConfigDirectory}.json`,
+		`${xdgConfigDirectory}.yaml`,
+		`${xdgConfigDirectory}.yml`,
+		`${xdgConfigDirectory}.toml`,
 	];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -767,6 +767,12 @@ importers:
       ollama-ai-provider-v2:
         specifier: catalog:ai
         version: 1.5.5(zod@4.2.1)
+      smol-toml:
+        specifier: 'catalog:'
+        version: 1.6.1
+      xdg-app-paths:
+        specifier: ^8.3.0
+        version: 8.3.0
       yargs:
         specifier: catalog:cli
         version: 18.0.0
@@ -9714,6 +9720,10 @@ packages:
     resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
     engines: {node: '>=0.10.0'}
 
+  os-paths@7.4.0:
+    resolution: {integrity: sha512-Ux1J4NUqC6tZayBqLN1kUlDAEvLiQlli/53sSddU4IN+h+3xxnv2HmRSMpVSvr1hvJzotfMs3ERvETGK+f4OwA==}
+    engines: {node: '>= 4.0'}
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -12470,6 +12480,14 @@ packages:
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
+
+  xdg-app-paths@8.3.0:
+    resolution: {integrity: sha512-mgxlWVZw0TNWHoGmXq+NC3uhCIc55dDpAlDkMQUaIAcQzysb0kxctwv//fvuW61/nAAeUBJMQ8mnZjMmuYwOcQ==}
+    engines: {node: '>= 4.0'}
+
+  xdg-portable@10.6.0:
+    resolution: {integrity: sha512-xrcqhWDvtZ7WLmt8G4f3hHy37iK7D2idtosRgkeiSPZEPmBShp0VfmRBLWAPC6zLF48APJ21yfea+RfQMF4/Aw==}
+    engines: {node: '>= 4.0'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -22073,6 +22091,10 @@ snapshots:
 
   os-homedir@1.0.2: {}
 
+  os-paths@7.4.0:
+    optionalDependencies:
+      fsevents: 2.3.3
+
   outdent@0.5.0: {}
 
   own-keys@1.0.1:
@@ -25154,6 +25176,18 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.0
+
+  xdg-app-paths@8.3.0:
+    dependencies:
+      xdg-portable: 10.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  xdg-portable@10.6.0:
+    dependencies:
+      os-paths: 7.4.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
Closes STE-39

Extends cosmiconfig searchPlaces in `core/ai-commit-msg/src/config.ts` to include XDG base-directory paths (`$XDG_CONFIG_HOME/ai-commit-msg/config.{json,yaml,yml,toml}`, fallback `$HOME/.config/ai-commit-msg/`). Adds a smol-toml cosmiconfig loader so .toml configs at the XDG path round-trip correctly. Project-local config files still take precedence over XDG-sourced ones.

## Acceptance criteria
- [x] A config at `~/.config/ai-commit-msg/config.json` is discovered and loaded
- [x] A config at `$XDG_CONFIG_HOME/ai-commit-msg/config.yaml` is discovered when `XDG_CONFIG_HOME` is set
- [x] TOML config files at the XDG path are parsed correctly
- [x] Local project config still takes precedence over XDG config
- [x] No regression in existing cosmiconfig search behaviour