### PR TITLE
fix(auto-readme): preserve GitHub admonitions through remark pipeline

### DIFF
--- a/core/auto-readme/package.json
+++ b/core/auto-readme/package.json
@@ -71,6 +71,7 @@
     "pkg-types": "catalog:",
     "remark": "catalog:remark",
     "remark-code-import": "catalog:remark",
+    "remark-github-blockquote-alert": "catalog:remark",
     "remark-collapse": "catalog:remark",
     "remark-toc": "catalog:remark",
     "simple-icons": "catalog:",

--- a/core/auto-readme/src/pipeline.ts
+++ b/core/auto-readme/src/pipeline.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { remark } from "remark";
 import remarkCodeImport from "remark-code-import";
 import remarkCollapse from "remark-collapse";
+import { remarkAlert } from "remark-github-blockquote-alert";
 import remarkToc from "remark-toc";
 import { VFile } from "vfile";
 
@@ -22,6 +23,7 @@ export async function parse(
 	data: ActionData,
 ) {
 	const pipeline = remark()
+		.use(remarkAlert)
 		.use(autoReadmeRemarkPlugin, config, data)
 		.use(remarkCodeImport, {});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,9 @@ catalogs:
     remark-collapse:
       specifier: 0.1.2
       version: 0.1.2
+    remark-github-blockquote-alert:
+      specifier: 1.3.1
+      version: 1.3.1
     remark-toc:
       specifier: 9.0.0
       version: 9.0.0
@@ -873,6 +876,9 @@ importers:
       remark-collapse:
         specifier: catalog:remark
         version: 0.1.2
+      remark-github-blockquote-alert:
+        specifier: catalog:remark
+        version: 1.3.1
       remark-toc:
         specifier: catalog:remark
         version: 9.0.0
@@ -10555,6 +10561,10 @@ packages:
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-github-blockquote-alert@1.3.1:
+    resolution: {integrity: sha512-OPNnimcKeozWN1w8KVQEuHOxgN3L4rah8geMOLhA5vN9wITqU4FWD+G26tkEsCGHiOVDbISx+Se5rGZ+D1p0Jg==}
+    engines: {node: '>=16'}
 
   remark-mdx@3.1.0:
     resolution: {integrity: sha512-Ngl/H3YXyBV9RcRNdlYsZujAmhsxwzxpDzpDEhFBVAGthS4GDgnctpDjgFl/ULx5UEDzqtW1cyBSNKqYYrqLBA==}
@@ -23065,6 +23075,10 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+
+  remark-github-blockquote-alert@1.3.1:
+    dependencies:
+      unist-util-visit: 5.1.0
 
   remark-mdx@3.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -188,6 +188,7 @@ catalogs:
     remark: 15.0.1
     remark-code-import: 1.2.0
     remark-collapse: 0.1.2
+    remark-github-blockquote-alert: 1.3.1
     remark-toc: 9.0.0
   schema:
     '@standard-schema/spec': 1.1.0


### PR DESCRIPTION
Closes STE-181

Adds `remark-github-blockquote-alert` to the remark pipeline in `core/auto-readme/src/pipeline.ts` so GitHub-style admonition syntax (`> [!NOTE]`, `> [!WARNING]`, etc.) round-trips through the auto-readme parser/serializer without being stripped or reformatted. Also adds the plugin to the workspace catalog under `catalog:remark`.

## Acceptance criteria
- [x] `remark-github-blockquote-alert` plugin imported in the pipeline
- [x] Added to catalog so other packages can adopt the same version
- [ ] Manual verification: run `auto-readme` on a README containing `> [!NOTE]` and confirm it is preserved