### PR TITLE
feat(auto-readme): add packageLinks preset badges (jsr, bundlesize)

### DIFF
--- a/core/auto-readme/src/plugin.ts
+++ b/core/auto-readme/src/plugin.ts
@@ -14,7 +14,11 @@ import { getContrastText } from "./color";
 import { parseComment } from "./comment";
 import { getSimpleIconColor } from "./icon";
 import { INFO } from "./log";
-import { defaultTableHeadings, defaultTemplates } from "./schema";
+import {
+	defaultTableHeadings,
+	defaultTemplates,
+	packageLinkPresets,
+} from "./schema";
 import { resolveVersion } from "./utilities";
 
 type TemplateContext = {
@@ -71,9 +75,20 @@ export const autoReadmeRemarkPlugin: Plugin<[Config, ActionData], Root> =
 			const skipTemplates =
 				first?.parameters.includes(`--skip-templates`);
 
+			const presetTemplates = (
+				config.badgeOptions?.packageLinks || []
+			).map(
+				(name) =>
+					packageLinkPresets[name as keyof typeof packageLinkPresets],
+			);
+			const allTemplates = [
+				...presetTemplates,
+				...(config.badgeOptions?.templates || []),
+			];
+
 			const templateBadges =
 				(!skipTemplates &&
-					config.badgeOptions?.templates.map((template) => {
+					allTemplates.map((template) => {
 						type TemplateType = Partial<
 							Record<
 								| "escaped_name"

--- a/core/auto-readme/src/schema.ts
+++ b/core/auto-readme/src/schema.ts
@@ -98,16 +98,50 @@ const badgeTemplateSchema = z
 			"handlebar template strings where {{scope}}, {{name}} / {{key}} and {{version}} / {{value}} represent the package",
 	});
 
+/**
+ * Built-in badge presets, keyed by short name. Each preset expands into the
+ * same {url,image,label} shape as a user-supplied badge template, so the
+ * Handlebars renderer can treat them identically.
+ */
+export const packageLinkPresets = {
+	bundlesize: {
+		image: "https://badgen.net/bundlephobia/min/{{name}}",
+		label: "minified size",
+		url: "https://bundlephobia.com/package/{{name}}",
+	},
+	bundlesizeGzip: {
+		image: "https://badgen.net/bundlephobia/minzip/{{name}}",
+		label: "minified + gzip size",
+		url: "https://bundlephobia.com/package/{{name}}",
+	},
+	jsr: {
+		image: "https://jsr.io/badges/{{name}}",
+		label: "jsr",
+		url: "https://jsr.io/{{name}}",
+	},
+} as const;
+
+const packageLinkPresetsSchema = z
+	.array(z.enum(Object.keys(packageLinkPresets) as [string, ...string[]]))
+	.default([])
+	.meta({
+		description:
+			"Built-in badge presets to include in the BADGE row. Each name expands to a {url,image,label} entry using the same Handlebars context as `templates`.",
+	});
+
 const _configSchema = z.object({
 	affectedRegexes: z.array(z.string().trim()),
 	badgeOptions: z
 		.object({
 			dependencyTypes: badgeDependencyTypeOptionsSchema,
+			packageLinks: packageLinkPresetsSchema,
 			templates: badgeTemplateSchema,
 		})
 		.default({
 			/* eslint-disable-next-line unicorn/no-useless-undefined */
 			dependencyTypes: badgeDependencyTypeOptionsSchema.parse(undefined),
+			/* eslint-disable-next-line unicorn/no-useless-undefined */
+			packageLinks: packageLinkPresetsSchema.parse(undefined),
 			/* eslint-disable-next-line unicorn/no-useless-undefined */
 			templates: badgeTemplateSchema.parse(undefined),
 		}),


### PR DESCRIPTION
Closes STE-38

Adds a new `badgeOptions.packageLinks` config field that lets consumers opt into built-in badge presets by short name instead of hand-rolling the full `{url, image, label}` shape. Three presets shipped in this PR:

- `jsr` — JSR registry badge
- `bundlesize` — bundlephobia minified size
- `bundlesizeGzip` — bundlephobia minified+gzip size

Usage:

```json
{
  "badgeOptions": {
    "packageLinks": ["jsr", "bundlesize", "bundlesizeGzip"]
  }
}
```

Presets expand into the same internal shape as user `templates` and pass through the existing Handlebars context, so `--skip-templates` skips them too. Presets are rendered **before** user templates in the BADGE row.

## Acceptance criteria
- [x] `jsr` preset emits the jsr.io badge linking to jsr.io/{name}
- [x] `bundlesize` preset emits the bundlephobia min badge
- [x] `bundlesizeGzip` preset emits the bundlephobia min+gzip badge
- [ ] `github` preset (needs `owner`/`repo` extraction from `pkg.repository.url` — deferred to a follow-up so this PR stays scoped)

## Notes
- README files across the monorepo will pick up the new badges automatically on next `auto-readme` run (config update in `.config/autoreadmerc.json` to add `packageLinks` is separate).