### PR TITLE
feat(auto-readme): add generate subcommand for default config

### DIFF
--- a/core/auto-readme/package.json
+++ b/core/auto-readme/package.json
@@ -57,6 +57,7 @@
     "@manypkg/get-packages": "catalog:manypkg",
     "@stephansama/mdast-zone": "catalog:",
     "@stephansama/remark-usage": "catalog:remark",
+    "cleye": "catalog:cli",
     "colord": "catalog:",
     "cosmiconfig": "catalog:cli",
     "deepmerge": "catalog:",

--- a/core/auto-readme/src/cli.ts
+++ b/core/auto-readme/src/cli.ts
@@ -1,8 +1,36 @@
 #!/usr/bin/env node
 
+import { cli, command } from "cleye";
+
 import { generate } from "./generate";
 import { run } from "./index";
 
-const [subcommand, ...rest] = process.argv.slice(2);
+const generateCommand = command(
+	{
+		flags: {
+			force: {
+				alias: "f",
+				default: false,
+				description: "Overwrite the target file if it already exists",
+				type: Boolean,
+			},
+		},
+		name: "generate",
+		parameters: ["[filename]"],
+	},
+	async (argv) => {
+		const passthrough: string[] = [];
+		if (argv._.filename) passthrough.push(argv._.filename);
+		if (argv.flags.force) passthrough.push("--force");
+		await generate(passthrough);
+	},
+);
 
-await (subcommand === "generate" ? generate(rest) : run());
+const argv = cli({
+	commands: [generateCommand],
+	name: "auto-readme",
+});
+
+if (!argv.command) {
+	await run();
+}

--- a/core/auto-readme/src/cli.ts
+++ b/core/auto-readme/src/cli.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
 
+import { generate } from "./generate";
 import { run } from "./index";
-await run();
+
+const [subcommand, ...rest] = process.argv.slice(2);
+
+await (subcommand === "generate" ? generate(rest) : run());

--- a/core/auto-readme/src/generate.ts
+++ b/core/auto-readme/src/generate.ts
@@ -1,0 +1,70 @@
+import * as fsp from "node:fs/promises";
+import path from "node:path";
+import { stringify as stringifyToml } from "smol-toml";
+import yaml from "yaml";
+
+import { configSchema } from "./schema";
+
+export type GenerateOptions = {
+	filename?: string;
+	force?: boolean;
+};
+
+const DEFAULT_FILENAME = ".autoreadmerc.json";
+
+export async function generate(argv: readonly string[]): Promise<void> {
+	const force = argv.includes("--force") || argv.includes("-f");
+	const positional = argv.find((argument) => !argument.startsWith("-"));
+	const filename = positional || DEFAULT_FILENAME;
+
+	if (!force && (await fileExists(filename))) {
+		throw new Error(
+			`Refusing to overwrite existing file: ${filename}. Pass --force to overwrite.`,
+		);
+	}
+
+	const defaults = buildDefaults();
+	const contents = serialize(filename, defaults);
+
+	await fsp.writeFile(filename, contents, "utf8");
+	// eslint-disable-next-line no-console
+	console.log(`Wrote ${filename}`);
+}
+
+/**
+ * Build the fully-populated default config object by parsing an empty seed
+ * through the Zod schema. Two top-level array fields (`affectedRegexes`,
+ * `collapseHeadings`) have no schema default, so we seed them with empty arrays
+ * here.
+ */
+function buildDefaults(): unknown {
+	return configSchema.unwrap().parse({
+		affectedRegexes: [],
+		collapseHeadings: [],
+	});
+}
+
+async function fileExists(filepath: string): Promise<boolean> {
+	try {
+		await fsp.access(filepath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function serialize(filename: string, defaults: unknown): string {
+	const extension = path.extname(filename).toLowerCase();
+	switch (extension) {
+		case ".toml": {
+			return stringifyToml(defaults as Record<string, unknown>);
+		}
+		case ".yaml":
+		case ".yml": {
+			return yaml.stringify(defaults);
+		}
+		default: {
+			return JSON.stringify(defaults, undefined, 2) + "\n";
+		}
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,6 +828,9 @@ importers:
       '@stephansama/remark-usage':
         specifier: catalog:remark
         version: 11.0.1
+      cleye:
+        specifier: catalog:cli
+        version: 2.6.0
       colord:
         specifier: 'catalog:'
         version: 2.9.3


### PR DESCRIPTION
Closes STE-13

Adds an `auto-readme generate [filename]` subcommand that writes a fully-populated default config file. Output format is detected from the filename extension:

- `.json` (default) → pretty-printed JSON
- `.yaml` / `.yml` → YAML via the `yaml` package
- `.toml` → TOML via `smol-toml`

Defaults are derived by passing an empty seed through `configSchema` (with empty arrays for the two top-level fields that have no schema default — `affectedRegexes`, `collapseHeadings`).

Refuses to overwrite an existing file unless `--force` / `-f` is passed.

## Acceptance criteria
- [x] `auto-readme generate` writes `.autoreadmerc.json` with all defaults
- [x] `auto-readme generate .autoreadmerc.yaml` writes YAML
- [x] `auto-readme generate .autoreadmerc.toml` writes TOML
- [x] Errors (with clear message) if the file already exists and `--force` is not passed
- [x] The generated file passes back through `configSchema.parse()` without errors (round-trip safe by construction)