### PR TITLE
fix(ai-commit-msg): clone env baseline to stop cumulative test mutations

### DIFF
--- a/core/ai-commit-msg/test/ai.test.ts
+++ b/core/ai-commit-msg/test/ai.test.ts
@@ -22,10 +22,14 @@ vi.mock("ollama-ai-provider-v2", () => ({
 /* eslint-enable @typescript-eslint/no-unsafe-assignment */
 
 describe("ai", () => {
-	const originalEnvironment = process.env;
+	// Clone (not capture by reference) so per-test `delete process.env.X`
+	// mutations don't leak into the "restored" baseline between cases.
+	// See STE-33 for the original flake — in CI, cumulative deletions broke
+	// later tests that expected a clean baseline.
+	const originalEnvironment = { ...process.env };
 
 	afterEach(() => {
-		process.env = originalEnvironment;
+		process.env = { ...originalEnvironment };
 		vi.clearAllMocks();
 	});
 


### PR DESCRIPTION
Closes STE-33

`core/ai-commit-msg/test/ai.test.ts` captured `const originalEnvironment = process.env` by **reference**, then individual tests did `delete process.env.X` to set up the "missing env" cases. The deletions mutated the same underlying object as `originalEnvironment`, so the `afterEach` restoration was a no-op for any key that had been deleted. In CI environments where additional env vars are present (`CI`, `GITHUB_ACTIONS`, etc.), the cumulative deletions corrupted the baseline that later tests relied on.

Fix: shallow-clone `process.env` into `originalEnvironment` once, and re-clone on each `afterEach` restoration. Net diff: 6 lines.

## Acceptance criteria
- [x] Tests still pass locally (`pnpm exec vitest run --root core/ai-commit-msg` → 27/27 green)
- [x] Lint passes
- [ ] CI runs no longer show intermittent failures in `ai.test.ts` (will confirm after merge)