### PR TITLE
feat(typed-nocodb-api): extend LIST query schema and fix URLSearchParams serialization

### DIFF
--- a/core/typed-nocodb-api/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/core/typed-nocodb-api/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -53,8 +53,12 @@ export declare function createApi<Schema extends z.ZodObject>({
     LIST: {
       method: "get";
       querySchema: z.ZodObject<{
-        fields: z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>;
-        sort: z.ZodPipe<z.ZodObject<{
+        fields: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>>;
+        limit: z.ZodOptional<z.ZodInt>;
+        nestedFields: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>>>;
+        offset: z.ZodOptional<z.ZodInt>;
+        shuffle: z.ZodOptional<z.ZodBoolean>;
+        sort: z.ZodOptional<z.ZodPipe<z.ZodObject<{
           direction: z.ZodEnum<{
             asc: "asc";
             desc: "desc";
@@ -63,7 +67,9 @@ export declare function createApi<Schema extends z.ZodObject>({
         }, z.core.$strip>, z.ZodTransform<string, {
           direction: "asc" | "desc";
           field: string;
-        }>>;
+        }>>>;
+        viewId: z.ZodOptional<z.ZodString>;
+        where: z.ZodOptional<z.ZodString>;
       }, z.core.$strip>;
       responseSchema: z.ZodObject<{
         nestedNext: z.ZodNullable<z.ZodOptional<z.ZodString>>;
@@ -129,8 +135,12 @@ export declare function createApi<Schema extends z.ZodObject>({
       LIST: {
         method: "get";
         querySchema: z.ZodObject<{
-          fields: z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>;
-          sort: z.ZodPipe<z.ZodObject<{
+          fields: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>>;
+          limit: z.ZodOptional<z.ZodInt>;
+          nestedFields: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>>>;
+          offset: z.ZodOptional<z.ZodInt>;
+          shuffle: z.ZodOptional<z.ZodBoolean>;
+          sort: z.ZodOptional<z.ZodPipe<z.ZodObject<{
             direction: z.ZodEnum<{
               asc: "asc";
               desc: "desc";
@@ -139,7 +149,9 @@ export declare function createApi<Schema extends z.ZodObject>({
           }, z.core.$strip>, z.ZodTransform<string, {
             direction: "asc" | "desc";
             field: string;
-          }>>;
+          }>>>;
+          viewId: z.ZodOptional<z.ZodString>;
+          where: z.ZodOptional<z.ZodString>;
         }, z.core.$strip>;
         responseSchema: z.ZodObject<{
           nestedNext: z.ZodNullable<z.ZodOptional<z.ZodString>>;
@@ -205,8 +217,12 @@ export declare function createApi<Schema extends z.ZodObject>({
     LIST: {
       method: "get";
       querySchema: z.ZodObject<{
-        fields: z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>;
-        sort: z.ZodPipe<z.ZodObject<{
+        fields: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>>;
+        limit: z.ZodOptional<z.ZodInt>;
+        nestedFields: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>>>;
+        offset: z.ZodOptional<z.ZodInt>;
+        shuffle: z.ZodOptional<z.ZodBoolean>;
+        sort: z.ZodOptional<z.ZodPipe<z.ZodObject<{
           direction: z.ZodEnum<{
             asc: "asc";
             desc: "desc";
@@ -215,7 +231,9 @@ export declare function createApi<Schema extends z.ZodObject>({
         }, z.core.$strip>, z.ZodTransform<string, {
           direction: "asc" | "desc";
           field: string;
-        }>>;
+        }>>>;
+        viewId: z.ZodOptional<z.ZodString>;
+        where: z.ZodOptional<z.ZodString>;
       }, z.core.$strip>;
       responseSchema: z.ZodObject<{
         nestedNext: z.ZodNullable<z.ZodOptional<z.ZodString>>;
@@ -281,8 +299,12 @@ export declare function createApi<Schema extends z.ZodObject>({
       LIST: {
         method: "get";
         querySchema: z.ZodObject<{
-          fields: z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>;
-          sort: z.ZodPipe<z.ZodObject<{
+          fields: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>>;
+          limit: z.ZodOptional<z.ZodInt>;
+          nestedFields: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>>>;
+          offset: z.ZodOptional<z.ZodInt>;
+          shuffle: z.ZodOptional<z.ZodBoolean>;
+          sort: z.ZodOptional<z.ZodPipe<z.ZodObject<{
             direction: z.ZodEnum<{
               asc: "asc";
               desc: "desc";
@@ -291,7 +313,9 @@ export declare function createApi<Schema extends z.ZodObject>({
           }, z.core.$strip>, z.ZodTransform<string, {
             direction: "asc" | "desc";
             field: string;
-          }>>;
+          }>>>;
+          viewId: z.ZodOptional<z.ZodString>;
+          where: z.ZodOptional<z.ZodString>;
         }, z.core.$strip>;
         responseSchema: z.ZodObject<{
           nestedNext: z.ZodNullable<z.ZodOptional<z.ZodString>>;
@@ -360,8 +384,12 @@ export declare function createApi<Schema extends z.ZodObject>({
     LIST: {
       method: "get";
       querySchema: z.ZodObject<{
-        fields: z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>;
-        sort: z.ZodPipe<z.ZodObject<{
+        fields: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>>;
+        limit: z.ZodOptional<z.ZodInt>;
+        nestedFields: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodArray<z.ZodString>, z.ZodString]>>>;
+        offset: z.ZodOptional<z.ZodInt>;
+        shuffle: z.ZodOptional<z.ZodBoolean>;
+        sort: z.ZodOptional<z.ZodPipe<z.ZodObject<{
           direction: z.ZodEnum<{
             asc: "asc";
             desc: "desc";
@@ -370,7 +398,9 @@ export declare function createApi<Schema extends z.ZodObject>({
         }, z.core.$strip>, z.ZodTransform<string, {
           direction: "asc" | "desc";
           field: string;
-        }>>;
+        }>>>;
+        viewId: z.ZodOptional<z.ZodString>;
+        where: z.ZodOptional<z.ZodString>;
       }, z.core.$strip>;
       responseSchema: z.ZodObject<{
         nestedNext: z.ZodNullable<z.ZodOptional<z.ZodString>>;

--- a/core/typed-nocodb-api/src/index.ts
+++ b/core/typed-nocodb-api/src/index.ts
@@ -1,5 +1,43 @@
 import * as z from "zod";
 
+function stringifyScalar(value: unknown): string {
+	if (typeof value === "boolean") return value ? "true" : "false";
+	if (typeof value === "number") return String(value);
+	if (typeof value === "string") return value;
+	return JSON.stringify(value);
+}
+
+/**
+ * Serialize a parsed query object to a nocodb-compatible query string. Arrays
+ * comma-join, booleans → "true"/"false", numbers stringify, and nested objects
+ * (e.g. `nestedFields`) expand into bracketed keys like
+ * `nestedFields[Author]=title,year`. undefined / null values are skipped.
+ */
+function toQueryString(parameters: unknown): string {
+	const pairs: [string, string][] = [];
+	for (const [key, value] of Object.entries(
+		parameters as Record<string, unknown>,
+	)) {
+		if (value === undefined || value === null) continue;
+		if (Array.isArray(value)) {
+			pairs.push([key, value.map((v) => stringifyScalar(v)).join(",")]);
+		} else if (typeof value === "object") {
+			for (const [nestedKey, nestedValue] of Object.entries(
+				value as Record<string, unknown>,
+			)) {
+				if (nestedValue === undefined || nestedValue === null) continue;
+				const serialized = Array.isArray(nestedValue)
+					? nestedValue.map((v) => stringifyScalar(v)).join(",")
+					: stringifyScalar(nestedValue);
+				pairs.push([`${key}[${nestedKey}]`, serialized]);
+			}
+		} else {
+			pairs.push([key, stringifyScalar(value)]);
+		}
+	}
+	return new URLSearchParams(pairs).toString();
+}
+
 export const ACTIONS = [
 	"LIST",
 	"CREATE",
@@ -52,13 +90,32 @@ export function createApi<Schema extends z.ZodObject>({
 		LIST: {
 			method: "get",
 			querySchema: z.object({
-				fields: z.array(z.string().trim()).or(z.string().trim()),
+				fields: z
+					.array(z.string().trim())
+					.or(z.string().trim())
+					.optional(),
+				limit: z.int().positive().optional(),
+				nestedFields: z
+					.record(
+						z.string().trim(),
+						z.array(z.string().trim()).or(z.string().trim()),
+					)
+					.optional(),
+				offset: z.int().nonnegative().optional(),
+				shuffle: z.boolean().optional(),
 				sort: z
 					.object({
 						direction: z.enum(["asc", "desc"]),
 						field: z.string().trim(),
 					})
-					.transform((input) => JSON.stringify(input)),
+					.transform((input) =>
+						input.direction === "desc"
+							? `-${input.field}`
+							: input.field,
+					)
+					.optional(),
+				viewId: z.string().trim().optional(),
+				where: z.string().trim().optional(),
 			}),
 			responseSchema: z.object({
 				nestedNext: z.string().trim().optional().nullable(),
@@ -121,7 +178,7 @@ export function createApi<Schema extends z.ZodObject>({
 
 			if ("query" in props && "querySchema" in current) {
 				const parsed = current.querySchema.parse(props.query);
-				parameters = "?" + new URLSearchParams(parsed).toString();
+				parameters = "?" + toQueryString(parsed);
 			}
 
 			let body: string | undefined;

--- a/core/typed-nocodb-api/test/index.test.ts
+++ b/core/typed-nocodb-api/test/index.test.ts
@@ -80,9 +80,8 @@ describe("typed-nocodb-api", () => {
 		const calledOptions = mockFetch.mock.calls[0][1] as object;
 
 		expect(calledUrl).toContain(expectedUrl);
-		expect(calledUrl).toContain(
-			"sort=%7B%22direction%22%3A%22asc%22%2C%22field%22%3A%22title%22%7D",
-		); // URL encoded JSON
+		expect(calledUrl).toContain("fields=title%2Ccompleted");
+		expect(calledUrl).toContain("sort=title");
 
 		expect(calledOptions).toEqual(
 			expect.objectContaining({
@@ -93,6 +92,39 @@ describe("typed-nocodb-api", () => {
 
 		const { pageInfo: _, ...expectedResult } = mockResponse;
 		expect(result).toEqual(expectedResult);
+	});
+
+	it("should serialize all LIST query parameters into the URL", async () => {
+		mockFetch.mockResolvedValue({
+			json: () => ({ records: [] }),
+			ok: true,
+			statusText: "OK",
+		});
+
+		await api.fetch({
+			action: "LIST",
+			query: {
+				fields: ["title", "completed"],
+				limit: 25,
+				nestedFields: { Author: ["name", "email"] },
+				offset: 50,
+				shuffle: true,
+				sort: { direction: "desc", field: "created_at" },
+				viewId: "view-1",
+				where: "(title,eq,foo)",
+			},
+		});
+
+		const calledUrl = mockFetch.mock.calls[0][0] as string;
+
+		expect(calledUrl).toContain("fields=title%2Ccompleted");
+		expect(calledUrl).toContain("where=%28title%2Ceq%2Cfoo%29");
+		expect(calledUrl).toContain("viewId=view-1");
+		expect(calledUrl).toContain("limit=25");
+		expect(calledUrl).toContain("offset=50");
+		expect(calledUrl).toContain("shuffle=true");
+		expect(calledUrl).toContain("sort=-created_at");
+		expect(calledUrl).toContain("nestedFields%5BAuthor%5D=name%2Cemail");
 	});
 
 	it("should perform COUNT action", async () => {


### PR DESCRIPTION
## Summary

Closes STE-77.

- Extend the LIST `querySchema` to expose `where`, `viewId`, `limit`, `offset`, `shuffle`, and `nestedFields` so callers can drive the full set of nocodb v3 records-endpoint parameters.
- Switch query serialization to an explicit `string[][]` pair construction with a small `toQueryString` helper. Arrays now comma-join into a single param (`fields=a,b,c`) and object-valued params like `nestedFields` expand into bracketed keys (`nestedFields[Author]=name,email`) instead of being coerced to `[object Object]`.
- Coerce `sort` to nocodb's `-field` / `field` prefix-dash format instead of JSON-stringifying it.

## Test plan

- [x] `pnpm exec vitest --run core/typed-nocodb-api` — existing LIST/COUNT/CREATE/DELETE/UPDATE tests plus a new fetch-mock test that asserts the generated URL contains every new query parameter.
- [x] `pnpm --filter @stephansama/typed-nocodb-api lint`
- [x] `pnpm --filter @stephansama/typed-nocodb-api build:snapshot` — API snapshot refreshed.