### PR TITLE
feat(workspace): add private/** to pnpm-workspace packages glob

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - core/**
   - examples/**
+  - private/**
   - scripts
   - www/*
 

--- a/private/README.md
+++ b/private/README.md
@@ -1,0 +1,3 @@
+# Private workspace packages
+
+This directory holds workspace packages marked `"private": true` in their `package.json` — internal tooling and prototypes that should not be published to npm. The `multipublish` and `changeset` configs already skip private packages, so adding one here is the only step required to keep it unpublished.


### PR DESCRIPTION
## Summary

Closes STE-146.

- Add `private/**` to the `packages:` glob list in `pnpm-workspace.yaml` so internal tooling and prototype packages marked `"private": true` can live in the workspace without ever being published.
- Add a `private/README.md` placeholder so the directory tracks under git and documents the convention.

`multipublish` already skips packages with `private: true` via its `onlyShowPublicPackages` config, and changesets natively excludes private packages from changelog entries — so no further config change is needed.

## Test plan

- [x] `pnpm install --ignore-scripts` resolves cleanly with the new glob (no new workspace projects detected, since `private/` is empty).
- [ ] Drop a package with `"private": true` into `private/`, run `pnpm install`, verify it can be referenced as a workspace dep and is skipped by `multipublish` / changeset publish.