### PR TITLE
chore: add astro iconify svgmap bugs metadata

### DIFF
--- a/.changeset/bright-maps-notice.md
+++ b/.changeset/bright-maps-notice.md
@@ -1,0 +1,5 @@
+---
+"@stephansama/astro-iconify-svgmap": patch
+---
+
+Add npm bugs metadata for the package.

--- a/core/astro-iconify-svgmap/package.json
+++ b/core/astro-iconify-svgmap/package.json
@@ -12,6 +12,9 @@
     "tanstack-intent"
   ],
   "homepage": "https://packages.stephansama.info/api/@stephansama/astro-iconify-svgmap",
+  "bugs": {
+    "url": "https://github.com/stephansama/packages/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/stephansama/packages.git",


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `@stephansama/astro-iconify-svgmap`
- point support links to the repository issue tracker, matching sibling package metadata

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('core/astro-iconify-svgmap/package.json','utf8')); console.log('package.json OK')"`
- `git diff --check`
