### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "root",
   "version": "1.0.0",
+  "bugs": {
+    "url": "https://github.com/stephansama/packages/issues"
+  },
   "private": true,
   "description": "root for @stephansama packages monorepo",
   "homepage": "https://packages.stephansama.info",


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.